### PR TITLE
Keep focus of webview elements (e.g. search input)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The prompt is a side effect of devdocs-electron not being a "signed" macOS app. 
 
 ## Contributing
 
-If you'd like to help improve devdocs-electron, give a look through this project's [CONTRIBUTING.md](https://github.com/jgarber623/devdocs-electron/bÂlob/master/CONTRIBUTING.md).
+If you'd like to help improve devdocs-electron, give a look through this project's [CONTRIBUTING.md](https://github.com/jgarber623/devdocs-electron/blob/master/CONTRIBUTING.md).
 
 ## Acknowledgments
 

--- a/app/main/window.js
+++ b/app/main/window.js
@@ -29,6 +29,10 @@ module.exports = class MainWindow {
 			this.browserWindow = null;
 		});
 
+		this.browserWindow.on('focus', () => {
+			this.browserWindow.webContents.send('window.focus');
+		});
+
 		return this;
 	}
 };

--- a/app/renderer/javascripts/webview.js
+++ b/app/renderer/javascripts/webview.js
@@ -40,6 +40,10 @@ module.exports = class Webview {
 			this.goToOffset(offset);
 		});
 
+		ipcRenderer.on('window.focus', () => {
+			this.$el.focus();
+		});
+
 		RadioRadio.subscribe('navigate.loadURL', (data) => {
 			this.loadURL(data.url);
 		});


### PR DESCRIPTION
Hi,

First of all: thanks for making this app. I use it almost daily.

This PR is fixes the issue that the focus of the elements in the webview is lost after alt-tabbing away, preventing you from searching for something new or using the spacebar to scroll down the current page without clicking in it first.

While I was busy trying to fix this I found that it is a known issue in the Electron project itself: https://github.com/electron/electron/issues/5900. Fortunately, the workaround that is mentioned there works here too. The webview should now behave the same as the website when the app's window is focused.

I have 0 experience in working with Electron so please tell me if there is a better way of doing this :)